### PR TITLE
Context menu bug fix + LogFile thread no longer consumes all CPU cycles

### DIFF
--- a/OSCWidgets/LogFile.cpp
+++ b/OSCWidgets/LogFile.cpp
@@ -127,6 +127,8 @@ void LogFile::run()
 					break;
 
 				stream.flush();
+
+				msleep(100);
 			}
 
 			stream.flush();

--- a/OSCWidgets/ToyGrid.cpp
+++ b/OSCWidgets/ToyGrid.cpp
@@ -895,7 +895,6 @@ void ToyGrid::resizeEvent(QResizeEvent *event)
 void ToyGrid::contextMenuEvent(QContextMenuEvent *event)
 {
 	QString name;
-	GetName(name);
 	
 	QMenu menu(this);
 	
@@ -942,6 +941,8 @@ void ToyGrid::contextMenuEvent(QContextMenuEvent *event)
 		menu.addMenu(gridSizeMenu);
 	}
 
+	GetName(name);
+	
 	if( hasLayoutMode )
 		menu.addAction(QIcon(":/assets/images/MenuIconSettings.png"), tr("Layout Mode..."), this, SLOT(onLayoutMode()));
 	else


### PR DESCRIPTION
Context menu bug fix:

By adding the window widget (OSCWidgets v0.6 -> v0.7) some labels in the context menu got broken.
This fix restores the original labels.

---

The LogFile thread no longer consumes all CPU cycles:

The LogFile thread consumed all CPU cycles, even when OSCWidgets was idle.

By adding a short sleep the problem is solved.

Because the messages are buffered, the sleep can be as long as desired.
I decided to sleep for 100ms.
